### PR TITLE
add support for Authorization Bearer jwt header

### DIFF
--- a/lib/event_types/api/jwt.js
+++ b/lib/event_types/api/jwt.js
@@ -80,6 +80,9 @@ class JWTValidator {
         }
 
         let token = utils.valueFromPath( event, this.tokenPath );
+        if (token && token.indexOf('Bearer') === 0) {
+          token = token.replace('Bearer', '').trim();
+        }
 
         let decoded = jwt.decode( token, this.algorithm, this.key );
 

--- a/test/lib/event_types/api/jwt.test.js
+++ b/test/lib/event_types/api/jwt.test.js
@@ -321,6 +321,37 @@ describe( MODULE_PATH, function() {
                 expect( event.jwt ).to.eql( decoded );
             });
 
+            it( 'jwt enabled, Bearer in header value', function() {
+              let instance = new JWTValidator( {
+
+                  algorithm: 'HS256',
+                  key: 'super-secret',
+                  token: 'headers.Authorization'
+              });
+
+              let event = {
+
+                  headers: {
+
+                      Authorization: 'Bearer jwt-here'
+                  }
+              };
+
+              const decoded = { claim1: 1, claim2: 2 };
+
+              jwtStub.decode.returns( decoded );
+
+              instance.validate( event );
+
+              expect( jwtStub.decode.calledOnce ).to.be.true;
+              expect( jwtStub.decode.firstCall.args ).to.eql( [ 'jwt-here', 'HS256', 'super-secret' ] );
+
+              expect( jwtStub.validateXSRF.called ).to.be.false;
+
+              expect( event.jwt ).to.exist;
+              expect( event.jwt ).to.eql( decoded );
+            });
+
             it( 'jwt enabled, with xsrf', function() {
 
                 let instance = new JWTValidator( {


### PR DESCRIPTION
adds support for passing a JWT token via the standard format of `Authorization: "Bearer token-value"`