### PR TITLE
Added rawBody to the API event.

### DIFF
--- a/lib/event_types/api/api_handler.js
+++ b/lib/event_types/api/api_handler.js
@@ -224,6 +224,8 @@ class APIHandler extends TypedHandler {
 
         if( event.body ) {
 
+            event.rawBody = event.body;
+
             event.body = processBody( event.body );
         }
 

--- a/test/lib/event_types/api/api_handler.test.js
+++ b/test/lib/event_types/api/api_handler.test.js
@@ -426,6 +426,11 @@ describe( MODULE_PATH, function() {
                 expect( state.event.body ).to.be.an( 'Object' );
                 expect( state.event.body.name ).to.exist;
                 expect( state.event.body.name ).to.equal( '   John Doe' );
+                expect( Object.getOwnPropertyNames( state.event.body ).length ).to.equal( 1 );
+
+                // rawBody should be present
+                expect( state.event.rawBody ).to.be.a( 'String' );
+                expect( state.event.rawBody ).to.equal( "{\r\n\t\"name\": \"   John Doe\"\r\n}" );
             });
 
             it( 'simple request with non-json body', function() {
@@ -460,6 +465,10 @@ describe( MODULE_PATH, function() {
                 // string encoded body should get parsed
                 expect( state.event.body ).to.be.a( 'String' );
                 expect( state.event.body ).to.equal( 'John Doe' );
+
+                // rawBody should be present
+                expect( state.event.rawBody ).to.be.a( 'String' );
+                expect( state.event.rawBody ).to.equal( 'John Doe' );
             });
 
             it( 'request without cookies', function() {


### PR DESCRIPTION
A fix for issue #25 .

The unaltered body of HTTP requests sent to API Gateway endpoints with vandiumized Lambda functions attached is available in  `event.rawBody`.

(also, I added [a one line fix](https://github.com/vandium-io/vandium-node/pull/26/commits/74c7506471e9cce9093989c56aa98afff46afbb3?diff=unified#diff-4b36b81639d5308a65f285d41b911126R429) to test that the parsed body has the correct number of object properties, this probably should have been in a separate commit, sorry my mistake!)