### PR TITLE
Add binary response support with isBase64Encoded flag

### DIFF
--- a/lib/event_types/api/api_handler.js
+++ b/lib/event_types/api/api_handler.js
@@ -47,7 +47,7 @@ function getStatusCode( httpMethod ) {
     }
 }
 
-function createProxyObject( body, statusCode, headers ) {
+function createProxyObject( body, statusCode, headers, isBase64Encoded ) {
 
     let proxyObject = {};
 
@@ -60,6 +60,7 @@ function createProxyObject( body, statusCode, headers ) {
     }
 
     proxyObject.body = body;
+    proxyObject.isBase64Encoded = isBase64Encoded || false;
 
     return proxyObject;
 }
@@ -248,8 +249,9 @@ class APIHandler extends TypedHandler {
         let headers = utils.clone( result.headers || this._headers );
 
         let body = result.body || result;
+        let isBase64Encoded = result.isBase64Encoded || false;
 
-        return { result: createProxyObject( body, statusCode, headers ) };
+        return { result: createProxyObject( body, statusCode, headers, isBase64Encoded ) };
     }
 
     processError( error ) {
@@ -270,7 +272,7 @@ class APIHandler extends TypedHandler {
             message: error.message
         };
 
-        return { result: createProxyObject( body, statusCode, headers ) };
+        return { result: createProxyObject( body, statusCode, headers, false ) };
     }
 
     _addHandler( type, ...args ) {

--- a/test/lib/event_types/api/get-event.json
+++ b/test/lib/event_types/api/get-event.json
@@ -1,0 +1,32 @@
+{
+    "resource": "/",
+    "path": "/",
+    "httpMethod": "GET",
+    "headers": null,
+    "queryStringParameters": null,
+    "pathParameters": null,
+    "stageVariables": null,
+    "requestContext": {
+        "accountId": "999999999999",
+        "resourceId": "5kwokute99",
+        "stage": "test-stage",
+        "requestId": "test-invoke-request",
+        "identity": {
+            "cognitoIdentityPoolId": null,
+            "accountId": "999999999999",
+            "cognitoIdentityId": null,
+            "caller": "999999999999",
+            "apiKey": "test-invoke-api-key",
+            "sourceIp": "test-invoke-source-ip",
+            "accessKey": "ASIAJ7WA3PXZVP6WUPZQ",
+            "cognitoAuthenticationType": null,
+            "cognitoAuthenticationProvider": null,
+            "userArn": "arn:aws:iam::999999999999:root",
+            "userAgent": "Apache-HttpClient/4.5.x (Java/1.8.0_102)",
+            "user": "999999999999"
+        },
+        "resourcePath": "/",
+        "apiId": "33hqk9a57e"
+    },
+    "isBase64Encoded": false
+}

--- a/test/lib/event_types/api/index.test.js
+++ b/test/lib/event_types/api/index.test.js
@@ -41,7 +41,7 @@ describe( MODULE_PATH, function() {
 
                 try {
 
-                    expect( result ).to.eql( { statusCode: 200, headers: {}, body: 'put called' } );
+                    expect( result ).to.eql( { statusCode: 200, headers: {}, body: 'put called', isBase64Encoded: false } );
                     done();
                 }
                 catch( e ) {
@@ -82,7 +82,7 @@ describe( MODULE_PATH, function() {
 
                 try {
 
-                    expect( result ).to.eql( { statusCode: 200, headers: {}, body: 'put called' } );
+                    expect( result ).to.eql( { statusCode: 200, headers: {}, body: 'put called', isBase64Encoded: false } );
                     done();
                 }
                 catch( e ) {
@@ -137,9 +137,41 @@ describe( MODULE_PATH, function() {
                             "Access-Control-Allow-Credentials": "true",
                             "Access-Control-Allow-Origin": "https://whatever.vandium.io"
                         },
+                        isBase64Encoded: false,
                         body: 'put called'
                     });
 
+                    done();
+                }
+                catch( e ) {
+
+                    done( e );
+                }
+            });
+        });
+
+        it( 'normal operation, with base64 encoded binary', function( done ) {
+
+            let handler = apiHandler();
+            let sampleBase64Png = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVQYV2P4DwABAQEAWk1v8QAAAABJRU5ErkJggg==';
+
+            handler.GET( {}, ( evt ) => {
+                return {
+                    headers: {
+                        'Content-Type': 'image/png'
+                    },
+                    isBase64Encoded: true,
+                    body: sampleBase64Png
+                }
+            });
+
+            let event = require( './get-event.json' );
+
+            handler( event, {}, (err,result) => {
+
+                try {
+
+                    expect( result ).to.eql( { statusCode: 200, headers: { 'Content-Type': 'image/png'}, body: sampleBase64Png, isBase64Encoded: true } );
                     done();
                 }
                 catch( e ) {

--- a/test/lib/index.test.js
+++ b/test/lib/index.test.js
@@ -70,7 +70,7 @@ describe( 'lib/index', function() {
                 .event( require( '../json/apigateway.json' ) )
                 .expectResult( (result) => {
 
-                    expect( result ).to.eql( { statusCode: 200, headers: {}, body: 'ok' } );
+                    expect( result ).to.eql( { statusCode: 200, headers: {}, body: 'ok', isBase64Encoded: false } );
                 });
         });
     });


### PR DESCRIPTION
To support binary payloads in the response of APIs, the isBase64Encoded field in the return payload needs to be whitelisted within the proxy object.  I default this value to false and have modified the existing tests accordingly.  I've also added a test for an example GET endpoint that returns a binary PNG encoded as a base64 string.  Finally, I have confirmed this change works in real life through an API Gateway defined endpoint using a lambda proxy to my code using vandium to define the endpoint.  It correctly recognizes the isBase64Encoded field in the response and decodes on the fly.