### PR TITLE
return 400 when error came from Joi

### DIFF
--- a/lib/validation/validation_provider.js
+++ b/lib/validation/validation_provider.js
@@ -17,7 +17,7 @@ class ValidationProvider {
 
         if( result.error ) {
 
-            throw result.error;
+            throw { statusCode: 400, name: result.error.name, message: result.error };
         }
 
         return result.value;

--- a/test/lib/event_types/api/validator.test.js
+++ b/test/lib/event_types/api/validator.test.js
@@ -147,7 +147,7 @@ describe( MODULE_PATH, function() {
                     }
                 };
 
-                expect( instance.validate.bind( instance, event ) ).to.throw( '"name" is required' );
+                expect( instance.validate.bind( instance, event ) ).to.throw( /"name" is required/ );
             });
 
             it( 'undefined value objects', function() {

--- a/test/lib/validation/validation_provider.test.js
+++ b/test/lib/validation/validation_provider.test.js
@@ -82,7 +82,7 @@ describe( MODULE_PATH, function() {
 
                 engine.validate.returns( { error: new Error( 'bang' ) } );
 
-                expect( provider.validate.bind( provider, values, schema, options ) ).to.throw( 'bang' );
+                expect( provider.validate.bind( provider, values, schema, options ) ).to.throw( /bang/ );
 
                 expect( engine.validate.calledOnce ).to.be.true;
                 expect( engine.validate.withArgs( values, schema, options ).calledOnce ).to.be.true;


### PR DESCRIPTION
returning 500 from a validation for an API request does not make sense. instead we should return 400