### PR TITLE
If validation schema is defined, do not allow unknown keys

### DIFF
--- a/lib/event_types/api/validator.js
+++ b/lib/event_types/api/validator.js
@@ -10,7 +10,14 @@ class SectionValidator {
 
         this.schema = new validation.createSchema( schema );
 
-        this.options = { allowUnknown: true };
+        this.options = { allowUnknown: this.isEmptyObject(schema) ? true : false }
+
+    }
+    
+    isEmptyObject(obj) {
+        
+        return obj.constructor === Object && Object.keys(obj).length === 0;
+ 
     }
 
     validate( event ) {


### PR DESCRIPTION
When you do not define a schema, it makes sense to allow "unknown" keys (e.g. keys you have not defined). However, if you explicitly specify a schema you would expect the validation to fail if it does not conform (e.g. contain undefined keys).

This small patch allows the unknown keys if you have no schema defined, yet sets Joi's `allowUnknown` to `false` if you do.