### PR TITLE
Extend error handling to provide custom body structure

### DIFF
--- a/lib/event_types/api/api_handler.js
+++ b/lib/event_types/api/api_handler.js
@@ -280,7 +280,7 @@ class APIHandler extends TypedHandler {
         let statusCode = error.status || error.statusCode || 500;
         let headers = utils.clone( error.headers || this._headers );
 
-        let body = {
+        let body = error.body || {
 
             type: error.name,
             message: error.message


### PR DESCRIPTION
The custom body structure allows to overwrite the error handling (e.g. implementing https://tools.ietf.org/html/rfc7807 structured errors).

Fixes #40 