### PR TITLE
Implement multiValueHeaders support in responses

### DIFF
--- a/lib/event_types/api/api_handler.js
+++ b/lib/event_types/api/api_handler.js
@@ -47,12 +47,13 @@ function getStatusCode( httpMethod ) {
     }
 }
 
-function createProxyObject( body, statusCode, headers, isBase64Encoded = false ) {
+function createProxyObject( body, statusCode, headers, multiValueHeaders, isBase64Encoded = false ) {
 
     let proxyObject = {};
 
     proxyObject.statusCode = statusCode;
     proxyObject.headers = headers;
+    proxyObject.multiValueHeaders = multiValueHeaders;
 
     if( body ) {
 
@@ -131,6 +132,7 @@ class APIHandler extends TypedHandler {
 
         this._jwt = new JWTValidator( options.jwt );
         this._headers = {};
+        this._multiValueHeaders = {};
         this._protection = new Protection( options.protection );
         this.methodHandlers = {};
         this._onErrorHandler = defaultOnError;
@@ -143,24 +145,56 @@ class APIHandler extends TypedHandler {
 
         return this;
     }
-
+    
     headers( options = {} ) {
+        
+        for( let key in options ) {
+            
+            this.header( key, options[ key ] );
+        }
+        
+        return this;
+    }
+    
+    header( name, value ) {
+        
+        if( name && ( value !== undefined && value !== null ) ) {
+
+            this._headers[ name ] = value.toString();
+        }
+        
+        return this;
+    }
+
+    multiValueHeaders( options = {} ) {
 
         for( let key in options ) {
 
-            this.header( key, options[ key ] );
+            this.multiValueHeader( key, options[ key ] );
         }
 
         return this;
     }
+    
+    multiValueHeader( name, value ) {
 
-    header( name, value ) {
+        if( name && (value !== undefined && value !== null ) ) {
 
-        if( name && (value !== undefined && value !== null) ) {
+            const multiValueHeader = ( this._multiValueHeaders[ name ] || [] );
+            let valueArray;
 
-            this._headers[ name ] = value.toString();
+            if( Array.isArray( value ) ) {
+
+                valueArray = value.map( val => val.toString() );
+
+            } else { 
+
+                valueArray = [ value.toString() ];
+            }
+
+            this._multiValueHeaders[ name ] = multiValueHeader.concat( valueArray );
         }
-
+            
         return this;
     }
 
@@ -196,6 +230,8 @@ class APIHandler extends TypedHandler {
         this.addlambdaHandlerMethod( 'jwt', lambdaHandler );
         this.addlambdaHandlerMethod( 'header', lambdaHandler );
         this.addlambdaHandlerMethod( 'headers', lambdaHandler );
+        this.addlambdaHandlerMethod( 'multiValueheader', lambdaHandler );
+        this.addlambdaHandlerMethod( 'multiValueheaders', lambdaHandler );
         this.addlambdaHandlerMethod( 'protection', lambdaHandler );
         this.addlambdaHandlerMethod( 'cors', lambdaHandler );
         this.addlambdaHandlerMethod( 'onError', lambdaHandler );
@@ -263,9 +299,10 @@ class APIHandler extends TypedHandler {
 
         let statusCode = result.statusCode || getStatusCode( context.event.httpMethod );
         let headers = utils.clone( result.headers || this._headers );
+        let multiValueHeaders = utils.clone( result.multiValueHeaders || this._multiValueHeaders );
         let isBase64Encoded = result.isBase64Encoded;
 
-        return { result: createProxyObject( body, statusCode, headers, isBase64Encoded ) };
+        return { result: createProxyObject(body, statusCode, headers, multiValueHeaders, isBase64Encoded ) };
     }
 
     processError( error, context ) {
@@ -279,6 +316,7 @@ class APIHandler extends TypedHandler {
 
         let statusCode = error.status || error.statusCode || 500;
         let headers = utils.clone( error.headers || this._headers );
+        let multiValueHeaders = utils.clone( error.multiValueHeaders || this._multiValueHeaders );
 
         let body = error.body || {
 
@@ -286,7 +324,7 @@ class APIHandler extends TypedHandler {
             message: error.message
         };
 
-        return { result: createProxyObject( body, statusCode, headers ) };
+        return { result: createProxyObject(body, statusCode, headers, multiValueHeaders ) };
     }
 
     _addHandler( type, ...args ) {

--- a/test/lib/event_types/api/api_handler.test.js
+++ b/test/lib/event_types/api/api_handler.test.js
@@ -244,6 +244,166 @@ describe( MODULE_PATH, function() {
             });
         });
 
+        describe( '.multiValueHeaders', function() {
+
+            it( 'normal operation', function() {
+
+                let instance = new APIHandler();
+                expect( instance._multiValueHeaders ).to.eql( {} );
+
+                let newHeaders = {
+
+                    header1: [ 'A', 'B' ],
+                };
+
+                let returnValue = instance.multiValueHeaders( newHeaders );
+                expect( returnValue ).to.equal( instance );
+
+                expect( instance._multiValueHeaders ).to.eql( newHeaders );
+                expect( instance._multiValueHeaders ).to.not.equal( newHeaders );  // should be cloned
+            });
+
+            it( 'called multple times to compound items', function() {
+
+                let instance = new APIHandler();
+                expect( instance._multiValueHeaders ).to.eql( {} );
+
+                let newHeaders = {
+
+                    header1: [ 'A', 'B' ],
+                };
+
+                let returnValue = instance.multiValueHeaders( newHeaders );
+                expect( returnValue ).to.equal( instance );
+
+                expect( instance._multiValueHeaders ).to.eql( newHeaders );
+
+                let newNewHeaders = {
+
+                    header1: [ 'C', 'D' ],
+                    header2: [ 'E', 'F' ],
+                };
+
+                instance.multiValueHeaders( newNewHeaders );
+                expect( instance._multiValueHeaders ).to.eql( {
+
+                    header1: [ 'A', 'B', 'C', 'D' ],
+                    header2: [ 'E', 'F' ],
+                });
+            });
+
+            it( 'called without arguments', function() {
+
+              let instance = new APIHandler();
+              expect( instance._multiValueHeaders ).to.eql( {} );
+
+              instance.multiValueHeaders();
+              expect( instance._multiValueHeaders ).to.eql( {} );
+            });
+        });
+
+        describe( '.multiValueHeader', function() {
+
+            it( 'normal operation', function() {
+
+                let instance = new APIHandler();
+                expect( instance._multiValueHeaders ).to.eql( {} );
+
+                let returnValue = instance.multiValueHeader( 'header1', [ 'A' ] );
+                expect( returnValue ).to.equal( instance );
+
+                expect( instance._multiValueHeaders ).to.eql( {
+
+                    header1: [ 'A' ],
+                });
+
+                instance.multiValueHeader( 'header2', 'B' );
+                expect( instance._multiValueHeaders ).to.eql( {
+
+                    header1: [ 'A' ],
+                    header2: [ 'B' ],
+                });
+            });
+
+            it( 'name is not set', function() {
+
+                let instance = new APIHandler();
+                expect( instance._multiValueHeaders ).to.eql( {} );
+
+                let returnValue = instance.multiValueHeader();
+                expect( returnValue ).to.equal( instance );
+
+                expect( instance._multiValueHeaders ).to.eql( {} );
+            });
+
+            it( 'value not set', function() {
+
+                let instance = new APIHandler();
+                expect( instance._multiValueHeaders ).to.eql( {} );
+
+                let returnValue = instance.multiValueHeader( 'myHeader' );
+                expect( returnValue ).to.equal( instance );
+
+                expect( instance._multiValueHeaders ).to.eql( {} );
+            });
+
+            it( 'value is false', function() {
+
+                let instance = new APIHandler();
+                expect( instance._multiValueHeaders ).to.eql( {} );
+
+                let returnValue = instance.multiValueHeader( 'myHeader', false );
+                expect( returnValue ).to.equal( instance );
+
+                expect( instance._multiValueHeaders ).to.eql( {
+
+                    myHeader: [ "false" ]
+                });
+            });
+
+            it( 'value is null', function() {
+
+                let instance = new APIHandler();
+                expect( instance._multiValueHeaders ).to.eql( {} );
+
+                let returnValue = instance.multiValueHeader( 'myHeader', null );
+                expect( returnValue ).to.equal( instance );
+
+                expect( instance._multiValueHeaders ).to.eql( {} );
+            });
+
+            it( 'key already exists', function() {
+
+                let instance = new APIHandler().multiValueHeader( 'header1', [ 'val1', 'val2' ] );
+                expect( instance._multiValueHeaders ).to.eql( { header1 : [ 'val1', 'val2' ] } );
+
+                let returnValue = instance.multiValueHeader( 'header1', [ 'val3' ] );
+                expect( returnValue ).to.equal( instance );
+
+                expect( instance._multiValueHeaders ).to.eql( { header1 : [ 'val1', 'val2', 'val3' ] } );
+            });
+
+            it( 'value is a single string or primitive and key does not exist', function() {
+
+                let instance = new APIHandler().multiValueHeader( 'header1', 'val1' );
+                expect( instance._multiValueHeaders ).to.eql( { header1 : [ 'val1' ] } );
+
+                let returnValue = instance.multiValueHeader( 'header2', 12 );
+                expect( instance._multiValueHeaders ).to.eql( { header1: [ 'val1' ], header2 : [ '12' ] } );
+            });
+
+            it( 'value is a single string or primitive and key already exists', function() {
+
+                let instance = new APIHandler().multiValueHeader( 'header1', 'val1' );
+                expect( instance._multiValueHeaders ).to.eql( { header1 : [ 'val1' ] } );
+
+                let returnValue = instance.multiValueHeader( 'header1', [ 'val2' ] );
+                expect( returnValue ).to.equal( instance );
+
+                expect( instance._multiValueHeaders ).to.eql( { header1 : [ 'val1', 'val2' ] } );
+            });
+        });
+
         describe( '.cors', function() {
 
             it( 'normal operation with partial cors', function() {
@@ -717,7 +877,7 @@ describe( MODULE_PATH, function() {
 
                 it( `defined headers for ${test[0]}`, function() {
 
-                    let instance = new APIHandler().headers( {header1: "1", header2: "2"});
+                    let instance = new APIHandler().headers( { header1: "1", header2: "2" });
 
                     let context = {
 
@@ -730,6 +890,24 @@ describe( MODULE_PATH, function() {
 
                     expect( resultObject.result.statusCode ).to.equal( test[1] );
                     expect( resultObject.result.headers ).to.eql( { header1: "1", header2: "2" } );
+                    expect( resultObject.result.body ).to.equal( 'OK' );
+                });
+
+                it( `defined multiValueHeaders for ${test[0]}`, function() {
+
+                    let instance = new APIHandler().multiValueHeaders( { 'Set-Cookie': [ 'val1', 'val2' ] } );
+
+                    let context = {
+
+                        event: Object.assign( {}, require( './put-event.json' ) )
+                    };
+
+                    context.event.httpMethod = test[0];
+
+                    let resultObject = instance.processResult( 'OK', context );
+
+                    expect( resultObject.result.statusCode ).to.equal( test[1] );
+                    expect( resultObject.result.multiValueHeaders ).to.eql( { 'Set-Cookie': [ 'val1', 'val2' ] } );
                     expect( resultObject.result.body ).to.equal( 'OK' );
                 });
 
@@ -748,16 +926,20 @@ describe( MODULE_PATH, function() {
 
                         statusCode: 999,
 
-                        headers: {
+                        multiValueHeaders: { 
+                            'Set-Cookie': [ 'val1', 'val2' ] 
+                        },
 
-                            header1: "1",
-                            header2: "2"
+                        headers: { 
+                            header1: '1', 
+                            header2: '2', 
                         },
                         body: { ok: true }
                     }, context );
 
                     expect( resultObject.result.statusCode ).to.equal( 999 );
                     expect( resultObject.result.headers ).to.eql( { header1: "1", header2: "2" } );
+                    expect( resultObject.result.multiValueHeaders ).to.eql( { 'Set-Cookie': ['val1', 'val2'] } );
                     expect( resultObject.result.body ).to.equal( "{\"ok\":true}");
                 });
             });

--- a/test/lib/event_types/api/index.test.js
+++ b/test/lib/event_types/api/index.test.js
@@ -41,7 +41,13 @@ describe( MODULE_PATH, function() {
 
                 try {
 
-                    expect( result ).to.eql( { statusCode: 200, headers: {}, body: 'put called', isBase64Encoded: false } );
+                    expect( result ).to.eql( { 
+                        statusCode: 200, 
+                        headers: {}, 
+                        multiValueHeaders: {}, 
+                        body: 'put called', 
+                        isBase64Encoded: false 
+                    });
                     done();
                 }
                 catch( e ) {
@@ -69,8 +75,8 @@ describe( MODULE_PATH, function() {
                 expect( evt.cookies ).to.eql( {
 
                     firstcookie: 'chocolate',
-                  secondcookie: 'chip',
-                  thirdcookie: 'strawberry'
+                    secondcookie: 'chip',
+                    thirdcookie: 'strawberry'
                 });
 
                 return 'put called';
@@ -82,7 +88,13 @@ describe( MODULE_PATH, function() {
 
                 try {
 
-                    expect( result ).to.eql( { statusCode: 200, headers: {}, body: 'put called', isBase64Encoded: false } );
+                    expect( result ).to.eql( { 
+                        statusCode: 200, 
+                        headers: {}, 
+                        multiValueHeaders: {}, 
+                        body: 'put called', 
+                        isBase64Encoded: false 
+                    });
                     done();
                 }
                 catch( e ) {
@@ -137,6 +149,7 @@ describe( MODULE_PATH, function() {
                             "Access-Control-Allow-Credentials": "true",
                             "Access-Control-Allow-Origin": "https://whatever.vandium.io"
                         },
+                        multiValueHeaders: {},
                         isBase64Encoded: false,
                         body: 'put called'
                     });
@@ -171,7 +184,7 @@ describe( MODULE_PATH, function() {
 
                 try {
 
-                    expect( result ).to.eql( { statusCode: 200, headers: { 'Content-Type': 'image/png'}, body: sampleBase64Png, isBase64Encoded: true } );
+                    expect( result ).to.eql( { statusCode: 200, headers: { 'Content-Type': 'image/png'}, multiValueHeaders: {}, body: sampleBase64Png, isBase64Encoded: true } );
                     done();
                 }
                 catch( e ) {
@@ -201,7 +214,7 @@ describe( MODULE_PATH, function() {
 
                 try {
 
-                    expect( result ).to.eql( { statusCode: 200, headers: { 'Content-Type': 'image/png'}, body: sampleBase64Png, isBase64Encoded: true } );
+                    expect( result ).to.eql( { statusCode: 200, headers: { 'Content-Type': 'image/png'}, multiValueHeaders: {}, body: sampleBase64Png, isBase64Encoded: true } );
                     done();
                 }
                 catch( e ) {
@@ -228,7 +241,13 @@ describe( MODULE_PATH, function() {
 
                 try {
 
-                    expect( result ).to.eql( { statusCode: 200, headers: { 'Content-Type': 'image/png'}, body: sampleBase64Png, isBase64Encoded: true } );
+                    expect( result ).to.eql( { 
+                        statusCode: 200, 
+                        headers: { 'Content-Type': 'image/png'}, 
+                        multiValueHeaders: {}, 
+                        body: sampleBase64Png, 
+                        isBase64Encoded: true 
+                    });
                     done();
                 }
                 catch( e ) {

--- a/test/lib/index.test.js
+++ b/test/lib/index.test.js
@@ -70,7 +70,7 @@ describe( 'lib/index', function() {
                 .event( require( '../json/apigateway.json' ) )
                 .expectResult( (result) => {
 
-                    expect( result ).to.eql( { statusCode: 200, headers: {}, body: 'ok', isBase64Encoded: false } );
+                    expect( result ).to.eql( { statusCode: 200, headers: {}, multiValueHeaders: {}, body: 'ok', isBase64Encoded: false } );
                 });
         });
     });


### PR DESCRIPTION
- Implemented auto parsing of multivalueheader responses.
- API is almost identical to those of regular headers - except it supports non-array single values as an arg ( those are enclosed in 1 length arrays )
- Added tests

Fixes #49 