### PR TITLE
Support single 'Set-Cookie' header via 'setCookie' key in result obj

### DIFF
--- a/lib/event_types/api/api_handler.js
+++ b/lib/event_types/api/api_handler.js
@@ -260,9 +260,21 @@ class APIHandler extends TypedHandler {
 
             body = result.body;
         }
-
+        
+        let responseCookie = result.setCookie;
+        
+        if( ( responseCookie !== undefined && responseCookie !== null ) && typeof responseCookie !== 'string' ) {
+            
+            responseCookie = cookie.serialize( result.setCookie.name, result.setCookie.value, result.setCookie.options );
+        }
+        
         let statusCode = result.statusCode || getStatusCode( context.event.httpMethod );
         let headers = utils.clone( result.headers || this._headers );
+        
+        if( ( responseCookie !== undefined && responseCookie !== null ) && typeof responseCookie == 'string' ) {
+        
+            Object.assign( headers, { 'Set-Cookie': responseCookie } );
+        }
         let isBase64Encoded = result.isBase64Encoded;
 
         return { result: createProxyObject( body, statusCode, headers, isBase64Encoded ) };

--- a/test/lib/event_types/api/api_handler.test.js
+++ b/test/lib/event_types/api/api_handler.test.js
@@ -10,6 +10,8 @@ const zlib = require( 'zlib' );
 
 const proxyquire = require( 'proxyquire' );
 
+const cookie = require( 'cookie' );
+
 const MODULE_PATH = 'lib/event_types/api/api_handler';
 
 const APIHandler = require( '../../../../' + MODULE_PATH );
@@ -733,7 +735,7 @@ describe( MODULE_PATH, function() {
                     expect( resultObject.result.body ).to.equal( 'OK' );
                 });
 
-                it( `result value for ${test[0]}`, function() {
+                it( `result value with single Set-Cookie header for ${test[0]}`, function() {
 
                     let instance = new APIHandler();
 
@@ -744,20 +746,40 @@ describe( MODULE_PATH, function() {
 
                     context.event.httpMethod = test[0];
 
+                    const resultCookie = { 
+                        name: 'first',
+                        value: 'cookie',
+                        options: {
+                            domain: 'domain.name',
+                            encode: encodeURIComponent,
+                            expires: new Date(),
+
+                            httpOnly: true,
+                            maxAge: 1000,
+                            path: '/',
+                            sameSite: true,
+                            secure: false,
+                        }
+                    }
+
                     let resultObject = instance.processResult( {
 
                         statusCode: 999,
-
+                        setCookie: resultCookie,
                         headers: {
 
                             header1: "1",
-                            header2: "2"
+                            header2: "2",
                         },
                         body: { ok: true }
                     }, context );
 
                     expect( resultObject.result.statusCode ).to.equal( 999 );
-                    expect( resultObject.result.headers ).to.eql( { header1: "1", header2: "2" } );
+                    expect( resultObject.result.headers ).to.eql( { 
+                        header1: "1", 
+                        header2: "2", 
+                        'Set-Cookie': cookie.serialize( resultCookie.name, resultCookie.value, resultCookie.options ), 
+                    });
                     expect( resultObject.result.body ).to.equal( "{\"ok\":true}");
                 });
             });


### PR DESCRIPTION
- Implements #47 
- Enables user to define a single `Set-Cookie` header in their response object via a `setCookie` key, which will be defined on `headers` as `Set-Cookie`.
- Empty setCookie will not add to headers

Only supports a single 'Set-Cookie' as multiValueHeaders is not yet supported in this release.

If we can get multiValueHeaders in I'll implement multiple Set-Cookies.

Also, the assertions I added may not be in the most useful of places, currently we run the setCookie assertion 4 times in the `.processResult()` tests.